### PR TITLE
SEO and W3C update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- SEO and W3C update
 - Added Twitter to footer
 - Deactivate "no-console" command
 - Added "node: true" to remove the linting errors
@@ -78,5 +79,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added impress and privacy as static html pages
 - Added linting and tests and Travis
 - Deployed via Netlify
-
-

--- a/public/datenschutz.html
+++ b/public/datenschutz.html
@@ -38,30 +38,13 @@
         }
     </style>
 
-    <!-- Matomo -->
-    <script type="text/javascript">
-        var _paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(["setDoNotTrack", true]);
-        _paq.push(["disableCookies"]);
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-        var u="//matomo.eventzimmer.de/";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '1']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    </script>
-    <!-- End Matomo Code -->
 </head>
 <body class="d-flex flex-column h-100">
     <noscript>
         <strong>We're sorry but eventzimmer doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
 
-    <main role="main" class="flex-shrink-0 w-auto">
+    <main class="flex-shrink-0 w-auto">
         <div class="container w-auto">
             <h3 class="mt-5">Datenschutzerklärung</h3>
 

--- a/public/impressum.html
+++ b/public/impressum.html
@@ -38,30 +38,13 @@
         }
     </style>
 
-    <!-- Matomo -->
-    <script type="text/javascript">
-        var _paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(["setDoNotTrack", true]);
-        _paq.push(["disableCookies"]);
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function() {
-        var u="//matomo.eventzimmer.de/";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '1']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-        })();
-    </script>
-    <!-- End Matomo Code -->
 </head>
 <body class="d-flex flex-column h-100">
     <noscript>
         <strong>We're sorry but eventzimmer doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
 
-    <main role="main" class="flex-shrink-0 w-auto">
+    <main class="flex-shrink-0 w-auto">
         <div class="container w-auto">
             <h3 class="mt-5">Impressum</h3>
 

--- a/public/imprint.html
+++ b/public/imprint.html
@@ -43,7 +43,7 @@
         <strong>We're sorry but eventzimmer doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
 
-    <main role="main" class="flex-shrink-0 w-auto">
+    <main class="flex-shrink-0 w-auto">
         <div class="container w-auto">
             <h3 class="mt-5">Impressum</h3>
 

--- a/public/index.html
+++ b/public/index.html
@@ -50,10 +50,6 @@
 	  h3 {
 		  margin-bottom: 10px;
 	  }
-	  h4 {
-		  font-size: 1.1rem;
-		  font-weight: bold;
-	  }
 
       .logo {
         display: block;

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="shortcut icon" type="image/png" href="<%= BASE_URL %>favicon.ico"/>
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
-    <title>eventzimmer</title>
+    <title>eventzimmer | Der Platz für alle Events in deiner Umgebung</title>
 
     <!-- SEO tags -->
     <meta name="description" content="Das eventzimmer bietet alle Events in Tübingen und anderswo!">
@@ -37,6 +37,24 @@
         background-color: transparent !important;
       }
 
+	  h1 {
+		  font-size: 1.8rem;
+		  margin-bottom: 0;
+		  text-align: center;
+	  }
+	  h2 {
+		  font-size: 1.2rem;
+		  margin-bottom: 40px;
+		  text-align: center;
+	  }
+	  h3 {
+		  margin-bottom: 10px;
+	  }
+	  h4 {
+		  font-size: 1.1rem;
+		  font-weight: bold;
+	  }
+
       .logo {
         display: block;
         margin-left: auto;
@@ -50,13 +68,13 @@
       <strong>We're sorry but eventzimmer doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
 
-    <main role="main" class="flex-shrink-0 w-auto">
+    <main class="flex-shrink-0 w-auto">
       <div class="container w-auto">
         <img alt="eventzimmer logo" src="<%= BASE_URL %>img/icons/icon-192x192.png" class="logo mt-3">
         <div id="app"></div>
       </div>
     </main>
-    
+
     <!-- Bootstrap JS with dependencies -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -43,7 +43,7 @@
         <strong>We're sorry but eventzimmer doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
 
-    <main role="main" class="flex-shrink-0 w-auto">
+    <main class="flex-shrink-0 w-auto">
         <div class="container w-auto">
             <h3 class="mt-5">Datenschutzerklärung</h3>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,8 @@
 <template>
   <div id="app">
-    <h3 class="mt-5">eventzimmer</h3>
+    <h1 class="mt-5">eventzimmer</h1>
+	<h2>{{ $t("msg.slogan") }}</h2>
+	<p>{{ $t("msg.introText") }}</p>
 
     <button type="button" @click="backToTop" id="back-to-top" class="btn btn-secondary btn-back-to-top fixed-bottom mb-2" style="display: none"><i class="fas fa-angle-up"></i></button>
     <div class="row mb-1 mt-1">

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1,6 +1,8 @@
 {
     "msg": {
         "page_wakeup": "Die Seite schläft gerade noch 💤. Gib uns einen Moment um sie aufzuwecken.",
+        "slogan": "Der Platz für alle Events in deiner Umgebung",
+        "introText": "Finde Events, Vorträge, Filme und viele weitere Ereignisse in deiner Stadt.",
         "events_in": "Veranstaltungen im",
         "cities": "Städte",
         "select_categories": "Kategorie(n) auswählen",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1,6 +1,8 @@
 {
     "msg": {
         "page_wakeup": "Page is still sleeping 💤. Give us a moment to wake up.",
+		"slogan": "The place for all events in your area",
+		"introText": "Find events, movies, exhibitions and more in your area.",
         "events_in": "Events in",
         "cities": "Cities",
         "select_categories": "Select categories",

--- a/src/components/Event.vue
+++ b/src/components/Event.vue
@@ -2,9 +2,9 @@
   <div class="card mb-1" :key="$store.state.selection.locale">
     <div class="card-body">
       <a :href="event.url" class="card-link" target="_blank" rel="noopener">
-        <h6 class="card-subtitle mb-1 text-muted">
+        <h4 class="card-subtitle mb-1 text-muted">
           {{ event.name }}
-        </h6>
+        </h4>
         <span class="badge badge-pill badge-secondary ml-1 overflow-auto">{{ distanceInWordsToNow(event.starts_at) }}</span>
         <span class="badge badge-pill badge-secondary ml-1 overflow-auto">{{ formatEventDate(event.starts_at) }}</span>
         <span class="badge badge-pill badge-secondary ml-1 d-inline-block text-truncate" style="max-width: 100%">{{ event.location.name }}</span>

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -1,8 +1,8 @@
 <template>
   <div v-if="!loading">
-    <p class="lead" v-if="$store.getters.currentMonthEvents.length">{{ $t("msg.events_in") }} {{ formatMonth(new Date()) }}</p>
+    <h3 class="lead" v-if="$store.getters.currentMonthEvents.length">{{ $t("msg.events_in") }} {{ formatMonth(new Date()) }}</h3>
     <event :event="event" v-for="event in $store.getters.currentMonthEvents" v-bind:key="event.url"></event>
-    <p class="lead mt-3" v-if="$store.getters.nextMonthEvents.length">{{ $t("msg.events_in") }} {{ formatMonth(nextMonth()) }}</p>
+    <h3 class="lead mt-3" v-if="$store.getters.nextMonthEvents.length">{{ $t("msg.events_in") }} {{ formatMonth(nextMonth()) }}</h3>
     <event :event="event" v-for="event in $store.getters.nextMonthEvents" v-bind:key="event.url"></event>
   </div>
   <div v-else>


### PR DESCRIPTION
Addressing some issues doing a W3C check and SEO check (https://www.seobility.net/en/seocheck/):

* add proper heading structure
* added a bit more text [h2, introText] (feel free to change them!) to make google more happy :smile: 
* removed all W3C warnings besides the script type from the autoinject (not sure where that is!)
* removed last matomo tags

![Screenshot_20191020_143421](https://user-images.githubusercontent.com/4334997/67159658-e6af8180-f347-11e9-915d-e9c27386d779.png)

![Screenshot_20191020_143534](https://user-images.githubusercontent.com/4334997/67159659-ee6f2600-f347-11e9-8479-75afd1cf61bd.png)


**TODO after the PR:**
* you can change the slogan/introText
* if you like: remove the last W3C warning to be 100% complete
* run seobility again after the changes are live